### PR TITLE
Removed Root Cause from terminology

### DIFF
--- a/draft-opsarea-rfc5706bis.md
+++ b/draft-opsarea-rfc5706bis.md
@@ -278,7 +278,7 @@ author:
    *  Fault: See {{?I-D.ietf-nmop-terminology}}.
 
    *  Fault Management: The process of interpreting fault notifications and other alerts
-      and alarms, isolating faults, correlating them, and decucing underlying
+      and alarms, isolating faults, correlating them, and deducing underlying
       Causes. See {{sec-fm-mgmt}} for more information.
 
    *  Information Model: An abstraction and representation of the


### PR DESCRIPTION
Taking this feedback into account (from https://github.com/IETF-OPSAWG-WG/draft-opsarea-rfc5706bis/pull/64)
- https://github.com/IETF-OPSAWG-WG/draft-opsarea-rfc5706bis/pull/64#issuecomment-2957855762
- https://github.com/IETF-OPSAWG-WG/draft-opsarea-rfc5706bis/pull/64#issuecomment-2960373446

The more I think about, the more I am convinced than we should not add Root Cause to our terminology section. On on side, the NMOP consensus was NOT to define that term. On the other side, the terminology fairy Adrian and the NMOP co-chair introduce it into another document. This does seem right, we can not say we were not aware. 

This Root Cause is going to painfully come back at us at review time, I believe.

Let's discuss today