### PR TITLE
Chongfeng issue 1

### DIFF
--- a/draft-opsarea-rfc5706bis.md
+++ b/draft-opsarea-rfc5706bis.md
@@ -301,7 +301,7 @@ contributor:
       combination of:
 
       1. Operation activities that are undertaken to keep the
-         network running normally. They include monitoring of the network.
+         network running as intended. They include monitoring of the network.
 
       2. Administration activities that keep track of resources in the
          network and how they are used. They include the bookkeeping necessary

--- a/draft-opsarea-rfc5706bis.md
+++ b/draft-opsarea-rfc5706bis.md
@@ -301,7 +301,7 @@ contributor:
       combination of:
 
       1. Operation activities that are undertaken to keep the
-         network. They include monitoring of the network.
+         network running normally. They include monitoring of the network.
 
       2. Administration activities that keep track of resources in the
          network and how they are used. They include the bookkeeping necessary


### PR DESCRIPTION
https://github.com/IETF-OPSAWG-WG/draft-opsarea-rfc5706bis/issues/97


    In Section 2.1, there is "Operation activities that are undertaken to keep the network."

It seems that this sentence is incomplete, can it be changed to the following or something like that? "Operation activities that are undertaken to keep the network run normally."