### PR TITLE
nits

### DIFF
--- a/draft-ietf-opsawg-rfc5706bis.md
+++ b/draft-ietf-opsawg-rfc5706bis.md
@@ -403,8 +403,8 @@ This document does not describe interoperability requirements. As such, it does 
    a more detailed discussion on what makes for a successful protocol.
 
    BGP flap damping {{?RFC2439}} is an example.  It was designed to block
-   high-frequency route flaps.  Some BGP implementations were memory-
-   constrained so often elected not to support this function, others found a
+   high-frequency route flaps.  Some BGP implementations were memory-constrained
+   so often elected not to support this function, others found a
    conflict where path exploration caused false flap damping resulting
    in loss of reachability.  As a result, flap damping was often not
    enabled network-wide, contrary to the intentions of the original


### PR DESCRIPTION
including breaking a very loooong para.

Some nits are only visible in the rendered version such as "end- to-end", "network- wide", etc.