### PR TITLE
Cite / Reference the BCP or the RFC within it?

### DIFF
--- a/draft-ietf-opsawg-rfc5706bis.md
+++ b/draft-ietf-opsawg-rfc5706bis.md
@@ -20,6 +20,9 @@ submissiontype: IETF
 coding: utf-8
 pi: [toc, sortrefs, symrefs]
 
+normative:
+   BCP22:
+
 informative:
   CHECKLIST:
     title: Operations and Management Review Checklist


### PR DESCRIPTION
Based on the description of the text on updating the BCP, not the RFC, it seems like the reference ought to be to BCP 22.