### PR TITLE
Coherence Between the Checklist and the Text

### DIFF
--- a/draft-ietf-opsawg-rfc5706bis.md
+++ b/draft-ietf-opsawg-rfc5706bis.md
@@ -420,7 +420,7 @@ This document does not describe interoperability requirements. As such, it does 
    options and parameters whenever possible. Any options and parameters
    should be configured or negotiated dynamically rather than manually.
 
-   The New Protocol or Protocol Extension should be able to can operate "out of the box".
+   The New Protocol or Protocol Extension should be able to operate "out of the box".
    To simplify configuration, Protocol Designers should
    specify reasonable defaults, including default modes and
    parameters. For example, define


### PR DESCRIPTION
I started comparing the checklist in Appendix A to the corresponding text.

I went through the first set in A.2. (Operational Fit):

> How does this protocol operate "out of the box"? (Section 4.1, Section 4.2)
> 
> What are the default values, modes, timers, and states? (Section 4.2)
> 
> What is the rationale for chosen default values, especially if they affect operations or are expected to change over time? (Section 4.2)



1. I believe the text can be simplified significantly. This PR effectively eliminates §4.1 (Operations). 
2. Some of the text that I eliminated (see below) didn't correspond to the questions and/or seemed to belong elsewhere.

Is this type of comparison useful?



## Eliminated text: 

> There may be a need to support both a human interface (e.g., for troubleshooting) and a programmatic interface (e.g., for automated monitoring and Cause analysis). The application programming interfaces (APIs) and the human interfaces might benefit from being similar to ensure that the information exposed by both is consistent when presented to an operator. It is also relevant to identify consistent methods for determining information, such as what is counted in specific counters.

The interface-related text seems to belong elsewhere -- §5?


> Protocol Designers should consider what management operations are expected to be performed as a result of the deployment of the protocol -- for example whether write operations are permitted on specific nodes (e.g., routers, hosts, including servers), or whether notifications for alarms or other events will be expected.

Management operations, belongs in §5 as well?


> Even if default values are used, it must be possible to retrieve all the actual values or at least an indication that known default values are being used.

Value retrieval, belongs in §5.3?


> Protocol Designers should consider how to enable operators to concentrate on the configuration of the network or service infrastructure as a whole rather than on individual devices. Of course, how one accomplishes this is the hard part.

What does this mean with respect to the documentation?